### PR TITLE
Add RFC3986 characters allowed in URI components CharacterSet 

### DIFF
--- a/Source/String.swift
+++ b/Source/String.swift
@@ -167,18 +167,26 @@ public struct CharacterSet: ExpressibleByArrayLiteral {
 	public static var digits: CharacterSet {
 		return ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
 	}
-	
+
 	public static var lowercase: CharacterSet {
 		return ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"]
 	}
-	
+
 	public static var uppercase: CharacterSet {
 		return ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
 	}
-	
+
 	public static var letters: CharacterSet {
 		return lowercase + uppercase
 	}
+
+    /// Based on [RFC3986 2.3 Unreserved Characters][1]
+    ///
+    /// [1]: https://tools.ietf.org/html/rfc3986#section-2.3
+
+    public static var uriComponentAllowed: CharacterSet {
+        return digits + letters + ["-", ".", "_", "~"]
+    }
 
     public static var uriQueryAllowed: CharacterSet {
         return digits + letters + ["!", "$", "&", "\'", "(", ")", "*", "+", ",", "-", ".", "/", ":", ";", "=", "?", "@", "_", "~"]

--- a/Tests/String/StringTests.swift
+++ b/Tests/String/StringTests.swift
@@ -95,6 +95,7 @@ extension StringTests {
     static var allTests: [(String, (StringTests) -> () throws -> Void)] {
         return [
            ("testHexadecimal", testHexadecimal),
+           ("testURIComponentPercentEncoding", testURIComponentPercentEncoding),
            ("testURIQueryPercentEncoding", testURIQueryPercentEncoding),
            ("testTrim", testTrim),
            ("testIndex", testIndex),

--- a/Tests/String/StringTests.swift
+++ b/Tests/String/StringTests.swift
@@ -33,6 +33,43 @@ class StringTests: XCTestCase {
         string.replace(string: "longnonexistentstring", with: "replacement string")
         XCTAssertEqual(string, "short")
     }
+    
+    func testURIComponentPercentEncoding() {
+        XCTAssertEqual(try "aBc123".percentEncoded(allowing: .uriComponentAllowed), "aBc123")
+        XCTAssertEqual(try "-._~".percentEncoded(allowing: .uriComponentAllowed), "-._~")
+        XCTAssertEqual(try "너가 보여".percentEncoded(allowing: .uriComponentAllowed), "%EB%84%88%EA%B0%80%20%EB%B3%B4%EC%97%AC")
+        XCTAssertEqual(try "💩".percentEncoded(allowing: .uriComponentAllowed), "%F0%9F%92%A9")
+        XCTAssertEqual(try "foo bar".percentEncoded(allowing: .uriComponentAllowed), "foo%20bar")
+        XCTAssertEqual(try "foo\nbar".percentEncoded(allowing: .uriComponentAllowed), "foo%0Abar")
+        
+        /// The following code was generated using this code:
+        ///   http://sandbox.onlinephpfunctions.com/code/ee5ecf05e114d9869ead7b45769c7c487ca46484
+        ///
+        /// It checks chracters from RFC3986 2.2 Reserved Characters as well as
+        /// section 2.3 Unreserved Characters
+        
+        XCTAssertEqual(try "co:on".percentEncoded(allowing: .uriComponentAllowed), "co%3Aon")
+        XCTAssertEqual(try "fs/ash".percentEncoded(allowing: .uriComponentAllowed), "fs%2Fash")
+        XCTAssertEqual(try "?mark".percentEncoded(allowing: .uriComponentAllowed), "%3Fmark")
+        XCTAssertEqual(try "#sign".percentEncoded(allowing: .uriComponentAllowed), "%23sign")
+        XCTAssertEqual(try "[sbracket]".percentEncoded(allowing: .uriComponentAllowed), "%5Bsbracket%5D")
+        XCTAssertEqual(try "@sign".percentEncoded(allowing: .uriComponentAllowed), "%40sign")
+        XCTAssertEqual(try "exc!amation".percentEncoded(allowing: .uriComponentAllowed), "exc%21amation")
+        XCTAssertEqual(try "do$$ar".percentEncoded(allowing: .uriComponentAllowed), "do%24%24ar")
+        XCTAssertEqual(try "ampers&".percentEncoded(allowing: .uriComponentAllowed), "ampers%26")
+        XCTAssertEqual(try "apos\'rophe".percentEncoded(allowing: .uriComponentAllowed), "apos%27rophe")
+        XCTAssertEqual(try "\"quote\"".percentEncoded(allowing: .uriComponentAllowed), "%22quote%22")
+        XCTAssertEqual(try "(paren)".percentEncoded(allowing: .uriComponentAllowed), "%28paren%29")
+        XCTAssertEqual(try "astr*ck".percentEncoded(allowing: .uriComponentAllowed), "astr%2Ack")
+        XCTAssertEqual(try "pl+us".percentEncoded(allowing: .uriComponentAllowed), "pl%2Bus")
+        XCTAssertEqual(try "com,ma".percentEncoded(allowing: .uriComponentAllowed), "com%2Cma")
+        XCTAssertEqual(try "semico;on".percentEncoded(allowing: .uriComponentAllowed), "semico%3Bon")
+        XCTAssertEqual(try "equ=als".percentEncoded(allowing: .uriComponentAllowed), "equ%3Dals")
+        XCTAssertEqual(try "da-sh".percentEncoded(allowing: .uriComponentAllowed), "da-sh")
+        XCTAssertEqual(try "per.od".percentEncoded(allowing: .uriComponentAllowed), "per.od")
+        XCTAssertEqual(try "_nderscore".percentEncoded(allowing: .uriComponentAllowed), "_nderscore")
+        XCTAssertEqual(try "til~de".percentEncoded(allowing: .uriComponentAllowed), "til~de")
+    }
 
     func testURIQueryPercentEncoding() {
         XCTAssertEqual(try "abc".percentEncoded(allowing: .uriQueryAllowed), "abc")

--- a/Tests/String/StringTests.swift
+++ b/Tests/String/StringTests.swift
@@ -39,6 +39,7 @@ class StringTests: XCTestCase {
         XCTAssertEqual(try "joão".percentEncoded(allowing: .uriQueryAllowed), "jo%C3%A3o")
         XCTAssertEqual(try "💩".percentEncoded(allowing: .uriQueryAllowed), "%F0%9F%92%A9")
         XCTAssertEqual(try "foo bar".percentEncoded(allowing: .uriQueryAllowed), "foo%20bar")
+        XCTAssertEqual(try "foo\nbar".percentEncoded(allowing: .uriQueryAllowed), "foo%0Abar")
     }
 
     func testTrim() {

--- a/Tests/String/StringTests.swift
+++ b/Tests/String/StringTests.swift
@@ -34,41 +34,52 @@ class StringTests: XCTestCase {
         XCTAssertEqual(string, "short")
     }
     
+
     func testURIComponentPercentEncoding() {
-        XCTAssertEqual(try "aBc123".percentEncoded(allowing: .uriComponentAllowed), "aBc123")
-        XCTAssertEqual(try "-._~".percentEncoded(allowing: .uriComponentAllowed), "-._~")
-        XCTAssertEqual(try "너가 보여".percentEncoded(allowing: .uriComponentAllowed), "%EB%84%88%EA%B0%80%20%EB%B3%B4%EC%97%AC")
-        XCTAssertEqual(try "💩".percentEncoded(allowing: .uriComponentAllowed), "%F0%9F%92%A9")
-        XCTAssertEqual(try "foo bar".percentEncoded(allowing: .uriComponentAllowed), "foo%20bar")
-        XCTAssertEqual(try "foo\nbar".percentEncoded(allowing: .uriComponentAllowed), "foo%0Abar")
-        
-        /// The following code was generated using this code:
+    
+        /// The following dictionary code was generated using:
         ///   http://sandbox.onlinephpfunctions.com/code/ee5ecf05e114d9869ead7b45769c7c487ca46484
-        ///
-        /// It checks chracters from RFC3986 2.2 Reserved Characters as well as
-        /// section 2.3 Unreserved Characters
         
-        XCTAssertEqual(try "co:on".percentEncoded(allowing: .uriComponentAllowed), "co%3Aon")
-        XCTAssertEqual(try "fs/ash".percentEncoded(allowing: .uriComponentAllowed), "fs%2Fash")
-        XCTAssertEqual(try "?mark".percentEncoded(allowing: .uriComponentAllowed), "%3Fmark")
-        XCTAssertEqual(try "#sign".percentEncoded(allowing: .uriComponentAllowed), "%23sign")
-        XCTAssertEqual(try "[sbracket]".percentEncoded(allowing: .uriComponentAllowed), "%5Bsbracket%5D")
-        XCTAssertEqual(try "@sign".percentEncoded(allowing: .uriComponentAllowed), "%40sign")
-        XCTAssertEqual(try "exc!amation".percentEncoded(allowing: .uriComponentAllowed), "exc%21amation")
-        XCTAssertEqual(try "do$$ar".percentEncoded(allowing: .uriComponentAllowed), "do%24%24ar")
-        XCTAssertEqual(try "ampers&".percentEncoded(allowing: .uriComponentAllowed), "ampers%26")
-        XCTAssertEqual(try "apos\'rophe".percentEncoded(allowing: .uriComponentAllowed), "apos%27rophe")
-        XCTAssertEqual(try "\"quote\"".percentEncoded(allowing: .uriComponentAllowed), "%22quote%22")
-        XCTAssertEqual(try "(paren)".percentEncoded(allowing: .uriComponentAllowed), "%28paren%29")
-        XCTAssertEqual(try "astr*ck".percentEncoded(allowing: .uriComponentAllowed), "astr%2Ack")
-        XCTAssertEqual(try "pl+us".percentEncoded(allowing: .uriComponentAllowed), "pl%2Bus")
-        XCTAssertEqual(try "com,ma".percentEncoded(allowing: .uriComponentAllowed), "com%2Cma")
-        XCTAssertEqual(try "semico;on".percentEncoded(allowing: .uriComponentAllowed), "semico%3Bon")
-        XCTAssertEqual(try "equ=als".percentEncoded(allowing: .uriComponentAllowed), "equ%3Dals")
-        XCTAssertEqual(try "da-sh".percentEncoded(allowing: .uriComponentAllowed), "da-sh")
-        XCTAssertEqual(try "per.od".percentEncoded(allowing: .uriComponentAllowed), "per.od")
-        XCTAssertEqual(try "_nderscore".percentEncoded(allowing: .uriComponentAllowed), "_nderscore")
-        XCTAssertEqual(try "til~de".percentEncoded(allowing: .uriComponentAllowed), "til~de")
+        let tests = [
+            // Quick RFC3986 2.3 Unreserved Characters simple tests
+            "aBc123":      "aBc123",
+            "-._~":        "-._~",
+            
+            // Misc. other tests.
+            "너가 보여":      "%EB%84%88%EA%B0%80%20%EB%B3%B4%EC%97%AC",
+            "💩":          "%F0%9F%92%A9",
+            "foo bar":     "foo%20bar",
+            "foo\nbar":    "foo%0Abar",
+            
+            // Quick RFC3986 2.2 Reserved Characters test
+            "co:on":       "co%3Aon",
+            "fs/ash":      "fs%2Fash",
+            "?mark":       "%3Fmark",
+            "#sign":       "%23sign",
+            "[sbracket]":  "%5Bsbracket%5D",
+            "@sign":       "%40sign",
+            "exc!amation": "exc%21amation",
+            "do$$ar":      "do%24%24ar",
+            "ampers&":     "ampers%26",
+            "apos\'rophe": "apos%27rophe",
+            "\"quote\"":   "%22quote%22",
+            "(paren)":     "%28paren%29",
+            "astr*ck":     "astr%2Ack",
+            "pl+us":       "pl%2Bus",
+            "com,ma":      "com%2Cma",
+            "semico;on":   "semico%3Bon",
+            "equ=als":     "equ%3Dals",
+            
+            // Quick RFC3986 2.3 Unreserved Characters test (non-alphanumeric)
+            "da-sh":       "da-sh",
+            "per.od":      "per.od",
+            "_nderscore":  "_nderscore",
+            "til~de":      "til~de"
+        ]
+        
+        for (raw, encoded) in tests {
+            XCTAssertEqual(try raw.percentEncoded(allowing: .uriComponentAllowed), encoded)
+        }
     }
 
     func testURIQueryPercentEncoding() {


### PR DESCRIPTION
This new character set is RFC3986 compliant and is useful for percent encoding individual components of a URI query string (keys, values). This is comparable to [PHP's `rawurlencode()`](http://php.net/manual/en/function.rawurlencode.php) or [JavaScript's `encodeURIComponent()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent).
